### PR TITLE
Fix release makefile #patch

### DIFF
--- a/.mk/release_release.mk
+++ b/.mk/release_release.mk
@@ -19,6 +19,7 @@ release/release:
 ifneq ($(NEXT_VERSION),)
 	@echo "Creating tag $(NEXT_VERSION)"
 	@git tag $(NEXT_VERSION)
+	@git push origin $(NEXT_VERSION)
 	@gh release create $(NEXT_VERSION) --generate-notes
 else
 	@echo "Last commit does not contain #major,#minor or #patch"


### PR DESCRIPTION
##  :pencil: Summary

Release workflow failed cause of makefile scripts. PR contains fixes to push to remote.

### :heavy_check_mark: Checks
* [ ] pre-commits are executed for your commit.
